### PR TITLE
fix(ci): pass --source ./home to chezmoi execute-template

### DIFF
--- a/.github/workflows/_upload-scripts.yml
+++ b/.github/workflows/_upload-scripts.yml
@@ -37,8 +37,8 @@ jobs:
           DOTFILES_RELEASE_TAG: ${{ inputs.tag_name }}
         run: |
           IMAGE_NAME_LC="${IMAGE_NAME,,}"
-          DOTFILES_IMAGE_NAME="${IMAGE_NAME_LC}" mise x -- chezmoi execute-template --file install.sh.tmpl > install.sh
-          DOTFILES_IMAGE_NAME="${IMAGE_NAME_LC}" mise x -- chezmoi execute-template --file install.ps1.tmpl > install.ps1
+          DOTFILES_IMAGE_NAME="${IMAGE_NAME_LC}" mise x -- chezmoi execute-template --source ./home --file install.sh.tmpl > install.sh
+          DOTFILES_IMAGE_NAME="${IMAGE_NAME_LC}" mise x -- chezmoi execute-template --source ./home --file install.ps1.tmpl > install.ps1
           chmod +x install.sh
 
       - name: Upload install scripts to release


### PR DESCRIPTION
## Summary

- `install.ps1.tmpl` calls `{{ includeTemplate ".chezmoitemplates/windows-elevation.ps1.tmpl" . }}`, which chezmoi resolves relative to its configured source directory.
- Without `--source`, `chezmoi execute-template` defaults to `~/.local/share/chezmoi/` (absent on CI runners), so the template lookup fails with *no such file or directory*.
- The actual templates live under `./home/.chezmoitemplates/` because `.chezmoiroot` is set to `home`.
- Fix: add `--source ./home` to both `chezmoi execute-template` invocations in `_upload-scripts.yml`.

## Test plan

- [ ] Re-run the `upload-scripts / upload` job (or trigger a new release) and confirm `Render install scripts from templates` succeeds for both `install.sh` and `install.ps1`.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ChipWolf/codesmith/dotfiles/pr/65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->