### PR TITLE
fix(git): use cross-platform null hooks path on Windows

### DIFF
--- a/home/dot_gitconfig.tmpl
+++ b/home/dot_gitconfig.tmpl
@@ -44,5 +44,11 @@
   helper = !mise x -- gh auth git-credential
 [include]
   path = ~/.gitconfig.overrides
+{{- if eq .chezmoi.os "windows" }}
+[core]
+  longpaths = true
+{{- end }}
+[core]
+  hooksPath = %(prefix)//dev/null
 [init]
   defaultBranch = main


### PR DESCRIPTION
## Summary

- Sets `core.hooksPath = %(prefix)//dev/null` in `.gitconfig` so git routes hook lookups to the null device on all platforms
- Adds `core.longpaths = true` under a Windows-only template guard to keep the setting that was previously deployed outside chezmoi

## Why

`/dev/null` is not a valid path on Windows — git interprets it as a literal relative path `dev\null\`, creates that directory, and writes hook stubs there. This produced untracked files (`dev/null/post-checkout`, `dev/null/post-commit`, etc.) in every Claude Code worktree, which then triggered an "Archive session with uncommitted changes?" modal on session close.

`%(prefix)//dev/null` is the portable git path that resolves to the null device on all platforms (Windows NUL, Unix /dev/null).

## Reviewer notes

- The `longpaths = true` line was already deployed to `~/.gitconfig` via a manual `git config` call; it's now managed by chezmoi so it won't be silently dropped on the next apply.
- No behaviour change on macOS/Linux — `hooksPath = %(prefix)//dev/null` is equivalent to the previous unset state (hooks were already not in use).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ChipWolf/codesmith/dotfiles/pr/68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->