### PR TITLE
chore(agents): gate Cursor/Codex/Claude tools to private systems

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,7 @@ Deleting a file from the chezmoi source does **not** remove it from the target (
 - **Install script templates** – `install.sh.tmpl` and `install.ps1.tmpl` are the source of truth for release installers. The release workflow renders `install.sh` and `install.ps1` from templates with repository/image/tag values before uploading release assets.
 - **Template readability** – Keep chezmoi template source files readable: use clear indentation, split complex logic into understandable blocks, and avoid flattening everything to the left margin with aggressive whitespace trimming unless required for output correctness.
 - **Bitwarden in automation** – Set `DOTFILES_SKIP_BITWARDEN=1` when running `chezmoi apply` in non-interactive/agent contexts. Templates that use the `bitwarden` function must honor this variable to avoid `bw` prompts/failures during automated runs.
+- **Cursor, Codex, and Claude-related tools deploy only on private machines** – Never add Cursor, Codex (`npm:@openai/codex`), Claude Code, Claude Desktop, or any other Claude/Anthropic tooling to a base/unconditional overlay. Gate them per subsystem: `{{ if .private }}` in chezmoi templates (e.g. `home/dot_config/mise/config.toml.tmpl`), `{ kind: env, name: PRIVATE, op: set }` in Brewfile overlay conditions, and `conditions: { private: true }` in `home/.chezmoidata/mcps/*.yaml` and `home/.chezmoidata/agent-permissions/*.yaml`. The `private` chezmoi data value is `true` on Windows or when `~/.private` exists (see `home/.chezmoi.toml.tmpl`).
 
 ---
 

--- a/home/dot_config/mise/config.toml.tmpl
+++ b/home/dot_config/mise/config.toml.tmpl
@@ -5,8 +5,8 @@ node = "latest"
 ruby = "latest"
 "npm:@mariozechner/pi-coding-agent" = "latest"
 "npm:context-mode" = "latest"
-"npm:@openai/codex" = "latest"
 {{ if .private -}}
+"npm:@openai/codex" = "latest"
 "npm:@anthropic-ai/claude-code" = "latest"
 {{ end -}}
 {{ end -}}


### PR DESCRIPTION
## Summary

- Add a `Repo-specific conventions` bullet to `AGENTS.md` requiring Cursor, Codex, Claude Code, Claude Desktop, and any Claude/Anthropic tooling to deploy only on private machines, with the gating mechanism per subsystem.
- Move `npm:@openai/codex` inside the existing `{{ if .private }}` block in `home/dot_config/mise/config.toml.tmpl` so it no longer installs on non-private systems.

## Why

`codex` was the only AI coding tool in this repo still installing unconditionally. The cursor brew cask (gated by `PRIVATE` env), claude-code (mise, gated by `{{ if .private }}`), and `Anthropic.Claude` (winget, Windows-only and Windows is always private) were already compliant. This change formalises the rule and brings codex in line.

## Reviewer notes

- The `private` chezmoi data value is `true` on Windows or when `~/.private` exists (see `home/.chezmoi.toml.tmpl`).
- No other entries currently violate the rule, per a sweep of `home/.chezmoidata/{brew,winget,chocolatey,mcps,agent-permissions}` and `home/dot_config/mise/config.toml.tmpl`.

Generated with [Claude Code](https://claude.com/claude-code)