### PR TITLE
fix(test): align choco-review bats assertion with script

### DIFF
--- a/tests/source/install.bats
+++ b/tests/source/install.bats
@@ -168,7 +168,7 @@ setup() {
   grep -q 'choco-packages.config.tmpl' "$REPO_ROOT/home/dot_scripts/executable_choco-review"
   grep -q '_dependency_packages' "$REPO_ROOT/home/dot_scripts/executable_choco-review"
   grep -q '_resolve_choco_lib_dir' "$REPO_ROOT/home/dot_scripts/executable_choco-review"
-  grep -q 'grep -qxF "\\$pkg"' "$REPO_ROOT/home/dot_scripts/executable_choco-review"
+  grep -q 'grep -qxF "\$pkg"' "$REPO_ROOT/home/dot_scripts/executable_choco-review"
   grep -q '_has_parent_package_installed' "$REPO_ROOT/home/dot_scripts/executable_choco-review"
 }
 


### PR DESCRIPTION
## Summary

- `tests/source/install.bats` line 171 asserts the script contains `grep -qxF \"\$pkg\"`, but the script actually contains `grep -qxF \"$pkg\"` (no backslash before the dollar).
- The bats single-quoted pattern `'grep -qxF \"\\$pkg\"'` becomes the literal string `grep -qxF \"\\$pkg\"`, which as a grep regex matches the text `grep -qxF \"\$pkg\"`. That string is not in the script, so the test has been failing on `main` since it was introduced.
- Fix: drop one backslash so the pattern matches `grep -qxF \"$pkg\"`.

## Why

This is the only failing assertion in test #56 (`bootstrap_windows: choco review filters genesis/dependency packages`); CI on `main` has been red on `source-tests (ubuntu-24.04)` because of it. The script itself is correct, the test over-escaped.

## Test plan

- [ ] `mise run pre-commit` passes (or `bats tests/source/install.bats` if pre-commit isn't bootstrapped).
- [ ] `source-tests` workflow goes green on this PR.

Generated with [Claude Code](https://claude.com/claude-code)