### PR TITLE
fix(scripts): quote suffix expansion in choco-review (SC2295)

### DIFF
--- a/home/dot_scripts/executable_choco-review
+++ b/home/dot_scripts/executable_choco-review
@@ -166,7 +166,7 @@ _has_parent_package_installed() {
 		;;
 	esac
 
-	local parent="${pkg%$suffix}"
+	local parent="${pkg%"$suffix"}"
 	[ -n "$parent" ] || return 1
 	echo "$installed_packages" | grep -qxF "$parent"
 }


### PR DESCRIPTION
## Summary

- `home/dot_scripts/executable_choco-review:169` had `local parent=\"\${pkg%\$suffix}\"`, which shellcheck flags as SC2295: the trailing `$suffix` is read as a pattern, not a literal string.
- Quote `$suffix` separately: `local parent=\"\${pkg%\"\$suffix\"}\"`. Now `${pkg%...}` strips a literal suffix instead of matching a glob.

## Why

MegaLinter on `main` has been failing on this single shellcheck error. It is a real (if low-severity) correctness issue: package names with shell-glob metacharacters would have been stripped incorrectly. The fix is the canonical SC2295 remediation.

## Test plan

- [ ] `shellcheck home/dot_scripts/executable_choco-review` reports no errors.
- [ ] MegaLinter on this PR shows `BASH/shellcheck` green.

Generated with [Claude Code](https://claude.com/claude-code)