### PR TITLE
fix(lint): exclude chezmoi modify_*.json templates from JSON linters

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -13,4 +13,9 @@ LUA_LUACHECK_ARGUMENTS: "--globals vim"
 
 CSS_STYLELINT_FILTER_REGEX_EXCLUDE: "(yasb/styles\\.css)"
 
+# chezmoi modify_* templates start with `{{- /* chezmoi:modify-template */ -}}`,
+# which is not valid JSON until rendered. Exclude them from JSON linters/formatters.
+JSON_JSONLINT_FILTER_REGEX_EXCLUDE: "(home/.*modify_[^/]*\\.json)"
+JSON_PRETTIER_FILTER_REGEX_EXCLUDE: "(home/.*modify_[^/]*\\.json)"
+
 REPOSITORY_KICS_ARGUMENTS: "--exclude-paths .github/workflows/e2e-install.yml"


### PR DESCRIPTION
## Summary

- These four chezmoi `modify_` templates begin with `{{- /* chezmoi:modify-template */ -}}`, which is not valid JSON until chezmoi renders them:
  - `home/AppData/Roaming/Claude/modify_claude_desktop_config.json`
  - `home/dot_pi/agent/modify_settings.json`
  - `home/modify_dot_claude.json`
  - `home/private_dot_mcpproxy/modify_mcp_config.json`
- `jsonlint` (blocking) fails on `home/modify_dot_claude.json` with `Parse error on line 1, column 3 — Unexpected token "-"`. `prettier` (non-blocking) fails the same way on all four.
- Fix: add `JSON_JSONLINT_FILTER_REGEX_EXCLUDE` and `JSON_PRETTIER_FILTER_REGEX_EXCLUDE` to `.mega-linter.yml` matching `home/.../modify_*.json`. `v8r` already validates the rendered shapes, so JSON schema coverage isn't lost.

## Why

MegaLinter on `main` has been failing on this single jsonlint error for some time. These template files aren't pure JSON, so JSON linters shouldn't run on them.

## Test plan

- [ ] MegaLinter on this PR shows `JSON/jsonlint` and `JSON/prettier` green.
- [ ] `jsonlint` still runs against the other 17 JSON files in the listing.

Generated with [Claude Code](https://claude.com/claude-code)