### PR TITLE
fix(lint): exclude vendored rtk.ts from ts-standard

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -13,4 +13,8 @@ LUA_LUACHECK_ARGUMENTS: "--globals vim"
 
 CSS_STYLELINT_FILTER_REGEX_EXCLUDE: "(yasb/styles\\.css)"
 
+# rtk.ts is vendored from https://github.com/rtk-ai/rtk and must not be modified
+# locally (see header comment in the file). Exclude it from ts-standard.
+TYPESCRIPT_STANDARD_FILTER_REGEX_EXCLUDE: "(home/dot_config/opencode/plugins/rtk\\.ts)"
+
 REPOSITORY_KICS_ARGUMENTS: "--exclude-paths .github/workflows/e2e-install.yml"


### PR DESCRIPTION
## Summary

- `home/dot_config/opencode/plugins/rtk.ts` is vendored from <https://github.com/rtk-ai/rtk> and explicitly marked at the top of the file: *"Keep in sync with upstream; do not modify locally."*
- `ts-standard` reports 12 issues against it (double-quoted strings, `strict-boolean-expressions`, trailing comma). Fixing them locally would defeat the vendor sync.
- Fix: add `TYPESCRIPT_STANDARD_FILTER_REGEX_EXCLUDE` for that single file in `.mega-linter.yml`. The other three .ts plugins under `home/dot_config/opencode/plugins/` continue to be linted.

## Why

MegaLinter on `main` has been failing on the `TYPESCRIPT/ts-standard` block solely because of the vendored file. Excluding it lets `ts-standard` keep enforcing style on our own plugins.

## Test plan

- [ ] MegaLinter on this PR shows `TYPESCRIPT/ts-standard` green.
- [ ] `ts-standard home/dot_config/opencode/plugins/*.ts` still flags issues in the non-vendored files if any are introduced.

Generated with [Claude Code](https://claude.com/claude-code)