### PR TITLE
chore(ci): full-scan MegaLinter on its own Renovate update PRs

### DIFF
--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -29,6 +29,9 @@ jobs:
         uses: oxsecurity/megalinter@8fbdead70d1409964ab3d5afa885e18ee85388bb # v9.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Force a full-repo scan when Renovate bumps the MegaLinter action,
+          # so the new version is exercised against every file before merging.
+          VALIDATE_ALL_CODEBASE: ${{ github.event_name == 'push' || (github.event.pull_request.user.login == 'renovate[bot]' && startsWith(github.head_ref, 'renovate/oxsecurity-megalinter-')) }}
 
       - name: Upload SARIF report
         if: always()


### PR DESCRIPTION
## Summary

- When Renovate opens a PR that bumps `oxsecurity/megalinter`, set `VALIDATE_ALL_CODEBASE=true` so the new MegaLinter version runs against every file, not just the workflow diff.
- Detection uses `github.event.pull_request.user.login == 'renovate[bot]'` plus `startsWith(github.head_ref, 'renovate/oxsecurity-megalinter-')`, which matches Renovate's existing branch-name convention for this action (e.g. [PR #70](https://github.com/ChipWolf/dotfiles/pull/70)'s `renovate/oxsecurity-megalinter-9.x`).
- Push-to-main and all other PRs keep their existing scan scope: the expression evaluates to `true` on `push` (matching MegaLinter's default on the default branch) and `false` on every other PR (matching the changed-files-only default).

## Why

A MegaLinter version bump can introduce new or stricter rules. Running it only over the workflow diff misses regressions hidden in unchanged files; a full repo scan on the upgrade PR surfaces them before merge so the auto-merge rule for minor/patch updates does not silently land a breaking version.

## Test plan

- [ ] Next Renovate `oxsecurity/megalinter` PR shows MegaLinter scanning the full repo (look for `VALIDATE_ALL_CODEBASE: true` in the action's startup log).
- [ ] A non-Renovate PR run on this branch (this PR) shows the normal changed-files-only scope.
- [ ] Push to `main` after merge runs a full scan as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)