### PR TITLE
fix(lint): forward GITHUB_TOKEN to zizmor for action audits

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -23,3 +23,10 @@ JSON_PRETTIER_FILTER_REGEX_EXCLUDE: "(home/.*modify_[^/]*\\.json)"
 TYPESCRIPT_STANDARD_FILTER_REGEX_EXCLUDE: "(home/dot_config/opencode/plugins/rtk\\.ts)"
 
 REPOSITORY_KICS_ARGUMENTS: "--exclude-paths .github/workflows/e2e-install.yml"
+
+# MegaLinter v9.5.0 stopped forwarding GITHUB_TOKEN to linter containers by
+# default. zizmor needs it to query the GitHub API while running audits like
+# `artipacked` (which lists tags for referenced actions); without it the audit
+# aborts with a 401 and is reported as an error.
+ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES:
+  - GITHUB_TOKEN


### PR DESCRIPTION
## Summary

Add `ACTION_ZIZMOR_UNSECURED_ENV_VARIABLES: [GITHUB_TOKEN]` to `.mega-linter.yml` so zizmor can reach the GitHub API when running its action audits.

## Why

MegaLinter v9.5.0 hardened linter sandboxing and no longer forwards `GITHUB_TOKEN` to linter containers by default. zizmor's `artipacked` audit (and others) call the GitHub API to list tags for referenced actions. Without the token, the audit aborts:

```
'artipacked' audit failed on file://.github/workflows/_build-container.yml
Caused by:
  1: couldn't list tags for actions/checkout
  2: request error while accessing GitHub API
  3: HTTP status client error (401 Unauthorized)
```

MegaLinter counts the audit crash as a linter error, which broke the full-repo scan run on [PR #70](https://github.com/ChipWolf/dotfiles/pull/70) (the Renovate bump to v9.5.0) once the new full-scan-on-Renovate-megalinter-PR logic from [#81](https://github.com/ChipWolf/dotfiles/pull/81) kicked in.

The fix matches the remediation MegaLinter itself suggests in the failure log. With the token forwarded, zizmor either passes cleanly or reports a real `artipacked` finding worth fixing on its own merits.

## Test plan

- [ ] CI on this PR shows zizmor either passing or reporting a real (non-401) finding.
- [ ] Once merged, PR #70's next CI run gets past the zizmor error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)