### PR TITLE
fix(workflows): set persist-credentials: false on actions/checkout

### DIFF
--- a/.github/workflows/_build-container.yml
+++ b/.github/workflows/_build-container.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Lowercase image name
         id: image

--- a/.github/workflows/_upload-scripts.yml
+++ b/.github/workflows/_upload-scripts.yml
@@ -24,6 +24,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:

--- a/.github/workflows/badgesort.yml
+++ b/.github/workflows/badgesort.yml
@@ -24,6 +24,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Generate badges
         # kics-scan ignore-line

--- a/.github/workflows/e2e-install.yml
+++ b/.github/workflows/e2e-install.yml
@@ -45,6 +45,8 @@ jobs:
       BW_PASSWORD: "CiTestPassword123!"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
@@ -110,6 +112,8 @@ jobs:
     runs-on: windows-2025
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:
@@ -161,6 +165,8 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:

--- a/.github/workflows/megalinter.yml
+++ b/.github/workflows/megalinter.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run MegaLinter
         uses: oxsecurity/megalinter@42bb470545e359597e7f12156947c436e4e3fb9a # v9.3.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
         with:

--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -21,6 +21,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       # NOTE: The repository wiki must be initialized first (create one wiki page manually).
       - name: Sync docs to wiki


### PR DESCRIPTION
## Summary

Add `with: persist-credentials: false` to every `actions/checkout` step in this repo (9 sites across 7 workflow files).

## Why

`actions/checkout` defaults to `persist-credentials: true`, which writes the GitHub token into the checked-out workspace's `.git/config`. Any later step that uploads the workspace as an artifact, logs it, or runs untrusted code with read access to it can exfiltrate the token. zizmor calls this out as the `artipacked` audit — see https://docs.zizmor.sh/audits/#artipacked.

Once [#84](https://github.com/ChipWolf/dotfiles/pull/84) unblocked zizmor's GitHub API access, the full-repo scan on [PR #70](https://github.com/ChipWolf/dotfiles/pull/70) (Renovate's bump to MegaLinter v9.5.0) found 37 `artipacked` violations across these workflows. This PR resolves all of them.

## Why it's safe

None of these workflows push back over the checkout's git remote:

- `_build-container.yml`, `_upload-scripts.yml`, `badgesort.yml`, `e2e-install.yml`, `megalinter.yml`, `test.yml` — read-only CI (lint/build/test). No git push needed.
- `wiki-sync.yml` — uses [`Andrew-Chen-Wang/github-wiki-action`](https://github.com/Andrew-Chen-Wang/github-wiki-action), which takes its own `token` input (defaulting to `github.token`) and handles cloning + pushing the wiki repo with that token. It does not consume the host checkout's git credentials.

`megalinter.yml` keeps its existing `fetch-depth: 0` (MegaLinter uses the full history for incremental linting); `persist-credentials: false` is added alongside.

## Test plan

- [ ] CI on this PR is green (no zizmor `artipacked` findings).
- [ ] After merge, PR #70's rebased CI run drops from 37 zizmor errors to 0.
- [ ] e2e-install runs (ubuntu/windows/macos), test runs, and the next push to main don't break — `mise install`, brew bundle, etc. all operate without push credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)