### PR TITLE
chore(ci): cancel in-flight E2E install runs when a PR is closed

### DIFF
--- a/.github/workflows/e2e-install.yml
+++ b/.github/workflows/e2e-install.yml
@@ -4,6 +4,7 @@ name: E2E install
 "on":
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, closed]
     paths:
       - "install.sh.tmpl"
       - "install.ps1.tmpl"
@@ -19,9 +20,14 @@ name: E2E install
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e-linux:
     name: E2E install (Linux)
+    if: github.event.action != 'closed'
     runs-on: ubuntu-24.04
     services:
       vaultwarden:
@@ -109,6 +115,7 @@ jobs:
 
   e2e-windows:
     name: E2E install (Windows)
+    if: github.event.action != 'closed'
     runs-on: windows-2025
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -162,6 +169,7 @@ jobs:
 
   e2e-macos:
     name: E2E install (macOS)
+    if: github.event.action != 'closed'
     runs-on: macos-15
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

Apply the cancel-on-close pattern already used by [megalinter.yml](.github/workflows/megalinter.yml) to `e2e-install.yml`:

1. Add `closed` to the `pull_request` `types` filter.
2. Add a `concurrency` group keyed on `${{ github.head_ref || github.ref }}` with `cancel-in-progress: true`.
3. Gate each of the three jobs (Linux / Windows / macOS) on `if: github.event.action != 'closed'`.

## How it works

When a PR is closed, GitHub queues a new workflow run with `action: closed`. Because it shares the concurrency group with the in-flight run, `cancel-in-progress: true` cancels the in-flight run. The new run starts but every job's `if` evaluates false, so all jobs skip and the run completes immediately as "skipped".

Net effect: closing a PR (merge or otherwise) terminates the slow E2E install jobs instead of letting them burn Linux/Windows/macOS runner minutes after the result is moot.

## Test plan

- [ ] Open a PR that touches a path the workflow watches, push enough to start E2E jobs, then close the PR — confirm the in-flight Linux/Windows/macOS jobs cancel within ~1 minute.
- [ ] Confirm normal open/synchronize/reopen events still run all three jobs.
- [ ] `workflow_dispatch` still runs (no `action` field → `null != 'closed'` is true).

🤖 Generated with [Claude Code](https://claude.com/claude-code)