### PR TITLE
fix(workflows): re-enable zizmor; fix template-injection and unpinned-image findings

### DIFF
--- a/.github/workflows/_build-container.yml
+++ b/.github/workflows/_build-container.yml
@@ -75,10 +75,11 @@ jobs:
 
       - name: Extract delta layers and push
         id: push
+        env:
+          IMAGE: ${{ steps.image.outputs.name }}
+          TAG: ${{ inputs.tag_name }}
         run: |
           set -euo pipefail
-          IMAGE="${{ steps.image.outputs.name }}"
-          TAG="${{ inputs.tag_name }}"
 
           # The Dockerfile adds exactly 2 layers on top of the base:
           #   1. COPY (dotfiles source)

--- a/.github/workflows/_upload-scripts.yml
+++ b/.github/workflows/_upload-scripts.yml
@@ -46,8 +46,9 @@ jobs:
       - name: Upload install scripts to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ inputs.tag_name }}
         run: |
-          gh release upload "${{ inputs.tag_name }}" \
+          gh release upload "$TAG_NAME" \
             install.sh \
             install.ps1 \
             --clobber

--- a/.github/workflows/e2e-install.yml
+++ b/.github/workflows/e2e-install.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-24.04
     services:
       vaultwarden:
-        image: vaultwarden/server:latest
+        image: vaultwarden/server:latest@sha256:d626d04934cd1192ad8ced1adb975099fca78cec33ab467d2d3c923cde7f3b0c
         ports:
           - 8222:80
         env:

--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -6,17 +6,11 @@ DISABLE:
 
 DISABLE_LINTERS:
   - PYTHON_PYLINT
-  # MegaLinter v9.5.0 enables two new blocking linters that surface
-  # pre-existing findings in this repo. Disable them here to keep the
-  # version bump scope-focused; addressing the underlying findings is
-  # tracked separately.
-  #   - zizmor reports template-injection (workflow inputs interpolated
-  #     into `run:` blocks) and unpinned-images (vaultwarden:latest in
-  #     e2e-install.yml).
-  #   - osv-scanner aborts with "No package sources found" because this
-  #     repo has no scannable manifests (go.mod, package.json, etc.) at
-  #     the root that osv-scanner recognises by default.
-  - ACTION_ZIZMOR
+  # osv-scanner has nothing to scan in this repo: it's a chezmoi dotfiles
+  # tree with no language manifests or lockfiles (no go.mod, package.json,
+  # uv.lock, Gemfile.lock, etc.). MegaLinter treats the scanner's "No
+  # package sources found" exit as a failure, so it stays disabled until
+  # this repo grows a real dependency manifest.
   - REPOSITORY_OSV_SCANNER
 
 SARIF_REPORTER: true


### PR DESCRIPTION
## Summary

- Re-enables `ACTION_ZIZMOR` in `.mega-linter.yml` (it was disabled in #70 to keep the MegaLinter v9.5.0 bump scope-focused) by fixing the three high-severity findings it surfaced.
- Keeps `REPOSITORY_OSV_SCANNER` disabled, but with a clearer comment: this repo has no language manifests / lockfiles, so osv-scanner has nothing to scan and aborts with "No package sources found".

## Zizmor fixes

- **`.github/workflows/_build-container.yml`** — `template-injection`: `IMAGE`/`TAG` now flow through an `env:` block on the "Extract delta layers and push" step instead of being interpolated directly into the `run:` script as `"\${{ inputs.tag_name }}"` etc.
- **`.github/workflows/_upload-scripts.yml`** — `template-injection`: `gh release upload "\${{ inputs.tag_name }}"` becomes `gh release upload "\$TAG_NAME"`, with `TAG_NAME` in the step's `env:`.
- **`.github/workflows/e2e-install.yml`** — `unpinned-images`: pinned the Vaultwarden service container to its current multi-arch digest, `vaultwarden/server:latest@sha256:d626d04934cd1192ad8ced1adb975099fca78cec33ab467d2d3c923cde7f3b0c`. Renovate auto-updates digests on pinned tags by default.

## OSV scanner

Confirmed this repo has no `go.mod`, `package.json`, `uv.lock`, `Gemfile.lock`, `Cargo.toml`, etc. anywhere — it is purely a chezmoi source tree. Leaving the scanner disabled until/unless a real dependency manifest is added; comment in `.mega-linter.yml` now says exactly that instead of just "deferred from #70".

## Test plan

- [ ] MegaLinter CI passes with both `ACTION_ZIZMOR` enabled and `REPOSITORY_OSV_SCANNER` skipped (no zizmor findings, no osv-scanner crash).
- [ ] E2E install jobs still resolve Vaultwarden from the pinned digest (Linux job seeds the test vault against the service).
- [ ] Release workflow (`_build-container`, `_upload-scripts`) still produces the same image and uploaded assets.