### PR TITLE
fix(git): create global gitignore to suppress Claude Code worktree artifacts

### DIFF
--- a/home/dot_gitignore
+++ b/home/dot_gitignore
@@ -1,0 +1,7 @@
+# Claude Code worktrees set core.hooksPath to a relative "dev/null" on
+# Windows, causing git-lfs to mkdir and drop hook stubs in ./dev/null/.
+# Ignore the directory globally so those stubs never appear as untracked.
+dev/null/
+
+# Claude Code local settings
+**/.claude/settings.local.json


### PR DESCRIPTION
## Summary

- Creates `~/.gitignore` (via chezmoi `home/dot_gitignore`) to globally ignore `dev/null/` directories and `.claude/settings.local.json`
- Fixes the recurring "Archive session with uncommitted changes?" modal in Claude Desktop that lists 4 git-lfs hook stubs (`post-checkout`, `post-commit`, `post-merge`, `pre-push`) under `dev/null/`

## Root cause

Claude Code sets `core.hooksPath` to a relative `dev/null` when creating worktrees on Windows. `git lfs install` interprets this as `./dev/null/`, creates the directory, and drops its hook stubs there. These appear as untracked files, triggering the archive warning on every session close.

The gitconfig already sets `core.excludesFile = ~/.gitignore` but that file never existed, so the excludes pattern had nowhere to live.

## Test plan

- [ ] `chezmoi apply` deploys `~/.gitignore`
- [ ] Open and archive a Claude Code session; no "uncommitted changes" modal appears
- [ ] Existing repos are unaffected (the `dev/null/` pattern only matches the literal directory name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)